### PR TITLE
convert `git2` to `gix`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +94,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +118,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
+name = "btoi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd6407f73a9b8b6162d8a2ef999fe6afd7cc15902ebf42c5cd296addf17e0ad"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,9 +163,6 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -164,6 +226,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
+name = "clru"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8191fa7302e03607ff0e237d4246cc043ff5b3cb9409d995172ba3bea16b807"
+
+[[package]]
+name = "cmake"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31c789563b815f77f4250caee12365734369f942439b7defd71e18a48197130"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +251,101 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
 
 [[package]]
 name = "csv"
@@ -197,6 +369,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2696e8a945f658fd14dc3b87242e6b80cd0f36ff04ea560fa39082368847946"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +404,18 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
+
+[[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encode_unicode"
@@ -245,12 +445,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239f7bfb930f820ab16a9cd95afc26f88264cf6905c960b340a615384aa3338a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "flate2"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+dependencies = [
+ "crc32fast",
+ "libz-ng-sys",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -265,27 +510,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.17.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b989d6a7ca95a362cf2cfc5ad688b3a467be1f87e480b8dad07fee8c79b0044"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "gitql"
 version = "0.6.0"
 dependencies = [
- "git2",
  "gitql-ast",
  "gitql-cli",
  "gitql-engine",
  "gitql-parser",
+ "gix",
 ]
 
 [[package]]
@@ -312,8 +544,8 @@ dependencies = [
 name = "gitql-engine"
 version = "0.4.0"
 dependencies = [
- "git2",
  "gitql-ast",
+ "gix",
  "regex",
 ]
 
@@ -326,6 +558,484 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06a8c9f9452078f474fecd2880de84819b8c77224ab62273275b646bf785f906"
+dependencies = [
+ "gix-actor",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-date",
+ "gix-diff",
+ "gix-discover",
+ "gix-features",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-lock",
+ "gix-macros",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "once_cell",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8c6778cc03bca978b2575a03e04e5ba6f430a9dd9b0f1259f0a8a9a5e5cc66"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-date",
+ "itoa",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b42ea64420f7994000130328f3c7a2038f639120518870436d31b8bde704493"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676ede3a7d37e7028e2889830349a6aca22efc1d2f2dd9fa3351c1a8ddb0c6a"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "memmap2",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1108c4ac88248dd25cc8ab0d0dae796e619fb72d92f88e30e00b29d61bb93cc4"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "once_cell",
+ "smallvec",
+ "thiserror",
+ "unicode-bom",
+ "winnow",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea7505b97f4d8e7933e29735a568ba2f86d8de466669d9f0e8321384f9972f47"
+dependencies = [
+ "bitflags 2.4.0",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7df669639582dc7c02737642f76890b03b5544e141caba68a7d6b4eb551e0d"
+dependencies = [
+ "bstr",
+ "itoa",
+ "thiserror",
+ "time",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45e342d148373bd9070d557e6fb1280aeae29a3e05e32506682d027278501eb"
+dependencies = [
+ "gix-hash",
+ "gix-object",
+ "imara-diff",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da4cacda5ee9dd1b38b0e2506834e40e66c08cf050ef55c344334c76745f277b"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-hash",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f414c99e1a7abc69b21f3225a6539d203b0513f1d1d448607c4ea81cdcf9ee59"
+dependencies = [
+ "crc32fast",
+ "crossbeam-channel",
+ "flate2",
+ "gix-hash",
+ "gix-trace",
+ "jwalk",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "prodash",
+ "sha1",
+ "sha1_smol",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "404795da3d4c660c9ab6c3b2ad76d459636d1e1e4b37b0c7ff68eee898c298d4"
+dependencies = [
+ "gix-features",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ac79c444193b0660fe0c0925d338bd338bd643e32138784dccfb12c628b892"
+dependencies = [
+ "bitflags 2.4.0",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ccf425543779cddaa4a7c62aba3fa9d90ea135b160be0a72dd93c063121ad4a"
+dependencies = [
+ "faster-hex",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409268480841ad008e81c17ca5a293393fbf9f2b6c2f85b8ab9de1f0c5176a16"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.14.0",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-lock"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1568c3d90594c60d52670f325f5db88c2d572e85c8dd45fabc23d91cadb0fd52"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8acb5ee668d55f0f2d19a320a3f9ef67a6999ad483e11135abcc2464ed18b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e5528d5b2c984044d547e696e44a8c45fa122e83cd8c2ac1da69bd474336be8"
+dependencies = [
+ "bstr",
+ "btoi",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0446eca295459deb3d6dd6ed7d44a631479f1b7381d8087166605c7a9f717c6"
+dependencies = [
+ "arc-swap",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be19ee650300d7cbac5829b637685ec44a8d921a7c2eaff8a245d8f2f008870c"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror",
+ "uluru",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1d370115171e3ae03c5c6d4f7d096f2981a40ddccb98dfd704c773530ba73b"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "home",
+ "once_cell",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475c86a97dd0127ba4465fbb239abac9ea10e68301470c9791a6dd5351cdc905"
+dependencies = [
+ "bstr",
+ "btoi",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cccbfa8d5cd9b86465f27a521e0c017de54b92d9fd37c143e49c658a2f04f3a"
+dependencies = [
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-validate",
+ "memmap2",
+ "thiserror",
+ "winnow",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678ba30d95baa5462df9875628ed40655d5f5b8aba7028de86ed57f36e762c6c"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3e80a5992ae446fe1745dd26523b86084e3f1b6b3e35377fe09b4f35ac8f151"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b806349bc1f668e09035800e07ac8045da4e39a8925a245d93142c4802224ec1"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92b9542ac025a8c02ed5d17b3fc031a111a384e859d0be3532ec4d58c40a0f28"
+dependencies = [
+ "bitflags 2.4.0",
+ "gix-path",
+ "libc",
+ "windows",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "9.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2762b91ff95e27ff3ea95758c0d4efacd7435a1be3629622928b8276de0f72a8"
+dependencies = [
+ "gix-fs",
+ "libc",
+ "once_cell",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b6d623a1152c3facb79067d6e2ecdae48130030cf27d6eb21109f13bd7b836"
+
+[[package]]
+name = "gix-traverse"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ec6358f8373fb018af8fc96c9d2ec6a5b66999e2377dc40b7801351fec409ed"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c79d595b99a6c7ab274f3c991735a0c0f5a816a3da460f513c48edf1c7bf2cc"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-path",
+ "home",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b85d89dc728613e26e0ed952a19583744e7f5240fcd4aa30d6c824ffd8b52f0f"
+dependencies = [
+ "fastrand 2.0.0",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05cab2b03a45b866156e052aa38619f4ece4adcb2f79978bfc249bc3b21b8c5"
+dependencies = [
+ "bstr",
+ "thiserror",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +1046,15 @@ name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -371,6 +1090,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
+dependencies = [
+ "ahash",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,21 +1138,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jwalk"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2735847566356cd2179a2a38264839308f7079fa96e6bd5a42d740460e003c56"
+dependencies = [
+ "crossbeam",
+ "rayon",
 ]
 
 [[package]]
@@ -430,27 +1169,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.15.2+1.6.4"
+name = "libz-ng-sys"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a80df2e11fb4a61f4ba2ab42dbe7f74468da143f1a75c74e11dee7c813f694fa"
+checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
 dependencies = [
- "cc",
+ "cmake",
  "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ee889ecc9568871456d42f603d6a0ce59ff328d291063a45cbdf0036baf6db"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -458,6 +1183,16 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -472,6 +1207,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memmap2"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f49388d20533534cd19360ad3d6a7dadc885944aa802ba3995040c5ec11288c6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,22 +1243,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "prettytable-rs"
@@ -514,12 +1312,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "prodash"
+version = "26.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794b5bf8e2d19b53dcdcec3e4bba628e20f5b6062503ba89281fa7037dd7bbcf"
 
 [[package]]
 name = "quote"
@@ -531,12 +1335,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -546,7 +1381,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
  "getrandom",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "thiserror",
 ]
 
@@ -562,6 +1397,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+
+[[package]]
 name = "regex-syntax"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,7 +1414,7 @@ version = "0.37.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -594,10 +1435,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
-name = "serde"
-version = "1.0.164"
+name = "same-file"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serde"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.188"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "sha1-asm",
+]
+
+[[package]]
+name = "sha1-asm"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ba6947745e7f86be3b8af00b7355857085dbdf8901393c89514510eb61f4e21"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
+
+[[package]]
+name = "smallvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "smawk"
@@ -613,13 +1516,27 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "fastrand 1.9.0",
+ "redox_syscall 0.3.5",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -674,6 +1591,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
+dependencies = [
+ "deranged",
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a942f44339478ef67935ab2bbaec2fb0322496cf3cbe84b261e06ac3814c572"
+dependencies = [
+ "time-core",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,10 +1636,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "uluru"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794a32261a1f5eb6a4462c81b59cec87b5c27d5deea7dd1ac8fc781c41d226db"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
+name = "unicode-bom"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e90c70c9f0d4d1ee6d0a7d04aa06cb9bbd53d8cfbdd62a0269a7c2eb640552"
 
 [[package]]
 name = "unicode-ident"
@@ -739,10 +1707,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "walkdir"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"
@@ -909,3 +1887,12 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,4 +25,4 @@ gitql-ast = { path = "./crates/gitql-ast", version = "0.2.0" }
 gitql-parser = { path = "./crates/gitql-parser", version = "0.3.0" }
 gitql-engine = { path = "./crates/gitql-engine", version = "0.4.0" }
 gitql-cli = { path = "./crates/gitql-cli", version = "0.4.0" }
-git2 = { version = "0.17.1", default-features = false }
+gix = { version = "0.53.0", default-features = false, features = ["max-performance"] }

--- a/crates/gitql-ast/src/lib.rs
+++ b/crates/gitql-ast/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod aggregation;
+pub mod date_utils;
 pub mod expression;
 pub mod function;
 pub mod object;
@@ -6,4 +7,3 @@ pub mod scope;
 pub mod statement;
 pub mod types;
 pub mod value;
-pub mod date_utils;

--- a/crates/gitql-engine/Cargo.toml
+++ b/crates/gitql-engine/Cargo.toml
@@ -9,5 +9,5 @@ license = "MIT"
 
 [dependencies]
 gitql-ast = { path = "../gitql-ast", version = "0.2.0" }
-git2 = { version = "0.17.1", default-features = false }
+gix = { version = "0.53.0", default-features = false, features = ["blob-diff"] }
 regex = "1.8.4"

--- a/crates/gitql-engine/src/engine.rs
+++ b/crates/gitql-engine/src/engine.rs
@@ -22,10 +22,7 @@ pub struct EvaluationValues {
     pub hidden_selections: Vec<std::string::String>,
 }
 
-pub fn evaluate(
-    repos: &Vec<git2::Repository>,
-    query: GQLQuery,
-) -> Result<EvaluationValues, String> {
+pub fn evaluate(repos: &Vec<gix::Repository>, query: GQLQuery) -> Result<EvaluationValues, String> {
     let mut groups: Vec<Vec<GQLObject>> = Vec::new();
     let mut alias_table: HashMap<String, String> = HashMap::new();
 

--- a/crates/gitql-engine/src/engine_executor.rs
+++ b/crates/gitql-engine/src/engine_executor.rs
@@ -21,7 +21,7 @@ use crate::engine_function::select_gql_objects;
 
 pub fn execute_statement(
     statement: &Box<dyn Statement>,
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     groups: &mut Vec<Vec<GQLObject>>,
     alias_table: &mut HashMap<String, String>,
     hidden_selection: &Vec<String>,
@@ -88,7 +88,7 @@ pub fn execute_statement(
 
 fn execute_select_statement(
     statement: &SelectStatement,
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     groups: &mut Vec<Vec<GQLObject>>,
     hidden_selections: &Vec<String>,
 ) -> Result<(), String> {

--- a/crates/gitql-engine/src/engine_function.rs
+++ b/crates/gitql-engine/src/engine_function.rs
@@ -1,3 +1,4 @@
+use gix::reference::Category;
 use std::collections::HashMap;
 
 use gitql_ast::expression::Expression;
@@ -8,7 +9,7 @@ use gitql_ast::value::Value;
 use crate::engine_evaluator::evaluate_expression;
 
 pub fn select_gql_objects(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     table: String,
     fields_names: &Vec<String>,
     fields_values: &Vec<Box<dyn Expression>>,
@@ -25,7 +26,7 @@ pub fn select_gql_objects(
 }
 
 fn select_references(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     fields_names: &Vec<String>,
     fields_values: &Vec<Box<dyn Expression>>,
     alias_table: &HashMap<String, String>,
@@ -42,7 +43,7 @@ fn select_references(
     let values_len = fields_values.len() as i64;
     let padding = names_len - values_len;
 
-    for reference_result in references {
+    for reference_result in references.all().unwrap() {
         if reference_result.is_err() {
             break;
         }
@@ -68,28 +69,34 @@ fn select_references(
             }
 
             if field_name == "name" {
-                let name = reference.shorthand().unwrap_or("").to_string();
+                let name = reference
+                    .name()
+                    .category_and_short_name()
+                    .map(|(_, sn)| sn)
+                    .unwrap_or("".into())
+                    .to_string();
                 let column_name = get_column_name(&alias_table, &"name".to_string());
                 attributes.insert(column_name, Value::Text(name));
                 continue;
             }
 
             if field_name == "full_name" {
-                let full_name = reference.name().unwrap_or("").to_string();
+                let full_name = reference.name().as_bstr().to_string();
                 let column_name = get_column_name(&alias_table, &"full_name".to_string());
                 attributes.insert(column_name, Value::Text(full_name));
                 continue;
             }
 
             if field_name == "type" {
+                let category = reference.name().category();
                 let column_name = get_column_name(&alias_table, &"type".to_string());
-                if reference.is_branch() {
+                if category.map_or(false, |cat| cat == Category::LocalBranch) {
                     attributes.insert(column_name, Value::Text("branch".to_owned()));
-                } else if reference.is_remote() {
+                } else if category.map_or(false, |cat| cat == Category::RemoteBranch) {
                     attributes.insert(column_name, Value::Text("remote".to_owned()));
-                } else if reference.is_tag() {
+                } else if category.map_or(false, |cat| cat == Category::Tag) {
                     attributes.insert(column_name, Value::Text("tag".to_owned()));
-                } else if reference.is_note() {
+                } else if category.map_or(false, |cat| cat == Category::Note) {
                     attributes.insert(column_name, Value::Text("note".to_owned()));
                 } else {
                     attributes.insert(column_name, Value::Text("other".to_owned()));
@@ -112,7 +119,7 @@ fn select_references(
 }
 
 fn select_commits(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     fields_names: &Vec<String>,
     fields_values: &Vec<Box<dyn Expression>>,
     alias_table: &HashMap<String, String>,
@@ -120,15 +127,16 @@ fn select_commits(
     let repo_path = repo.path().to_str().unwrap().to_string();
 
     let mut commits: Vec<GQLObject> = Vec::new();
-    let mut revwalk = repo.revwalk().unwrap();
-    revwalk.push_head().unwrap();
+    let revwalk = repo.head_id().unwrap().ancestors().all().unwrap();
 
     let names_len = fields_names.len() as i64;
     let values_len = fields_values.len() as i64;
     let padding = names_len - values_len;
 
-    for commit_id in revwalk {
-        let commit = repo.find_commit(commit_id.unwrap()).unwrap();
+    for commit_info in revwalk {
+        let commit_info = commit_info.unwrap();
+        let commit = repo.find_object(commit_info.id).unwrap().into_commit();
+        let commit = commit.decode().unwrap();
 
         let mut attributes: HashMap<String, Value> = HashMap::new();
 
@@ -150,35 +158,35 @@ fn select_commits(
             }
 
             if field_name == "commit_id" {
-                let commit_id = Value::Text(commit.id().to_string());
+                let commit_id = Value::Text(commit_info.id.to_string());
                 let column_name = get_column_name(&alias_table, &"commit_id".to_string());
                 attributes.insert(column_name, commit_id);
                 continue;
             }
 
             if field_name == "name" {
-                let name = commit.author().name().unwrap_or("").to_string();
+                let name = commit.author().name.to_string();
                 let column_name = get_column_name(&alias_table, &"name".to_string());
                 attributes.insert(column_name, Value::Text(name));
                 continue;
             }
 
             if field_name == "email" {
-                let email = commit.author().email().unwrap_or("").to_string();
+                let email = commit.author().email.to_string();
                 let column_name = get_column_name(&alias_table, &"email".to_string());
                 attributes.insert(column_name, Value::Text(email));
                 continue;
             }
 
             if field_name == "title" {
-                let summary = Value::Text(commit.summary().unwrap().to_string());
+                let summary = Value::Text(commit.message().summary().to_string());
                 let column_name = get_column_name(&alias_table, &"title".to_string());
                 attributes.insert(column_name, summary);
                 continue;
             }
 
             if field_name == "message" {
-                let message = Value::Text(commit.message().unwrap_or("").to_string());
+                let message = Value::Text(commit.message.to_string());
                 let column_name = get_column_name(&alias_table, &"message".to_string());
                 attributes.insert(column_name, message);
                 continue;
@@ -186,8 +194,10 @@ fn select_commits(
 
             if field_name == "time" {
                 let column_name = get_column_name(&alias_table, &"time".to_string());
-                let time_stamp = commit.time().seconds();
-                attributes.insert(column_name, Value::DateTime(time_stamp));
+                let time_stamp = commit_info
+                    .commit_time
+                    .unwrap_or_else(|| commit.time().seconds);
+                attributes.insert(column_name, Value::Date(time_stamp));
                 continue;
             }
 
@@ -206,14 +216,18 @@ fn select_commits(
 }
 
 fn select_diffs(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     fields_names: &Vec<String>,
     fields_values: &Vec<Box<dyn Expression>>,
     alias_table: &HashMap<String, String>,
 ) -> Vec<GQLObject> {
+    let repo = {
+        let mut repo = repo.clone();
+        repo.object_cache_size_if_unset(4 * 1024 * 1024);
+        repo
+    };
     let mut diffs: Vec<GQLObject> = Vec::new();
-    let mut revwalk = repo.revwalk().unwrap();
-    revwalk.push_head().unwrap();
+    let revwalk = repo.head_id().unwrap().ancestors().all().unwrap();
 
     let repo_path = repo.path().to_str().unwrap().to_string();
 
@@ -221,8 +235,9 @@ fn select_diffs(
     let values_len = fields_values.len() as i64;
     let padding = names_len - values_len;
 
-    for commit_id in revwalk {
-        let commit = repo.find_commit(commit_id.unwrap()).unwrap();
+    for commit_info in revwalk {
+        let commit_info = commit_info.unwrap();
+        let commit = commit_info.id().object().unwrap().into_commit();
         let mut attributes: HashMap<String, Value> = HashMap::new();
 
         for index in 0..names_len {
@@ -244,19 +259,19 @@ fn select_diffs(
 
             if field_name == "commit_id" {
                 let column_name = get_column_name(&alias_table, &"commit_id".to_string());
-                attributes.insert(column_name, Value::Text(commit.id().to_string()));
+                attributes.insert(column_name, Value::Text(commit_info.id.to_string()));
                 continue;
             }
 
             if field_name == "name" {
-                let name = commit.author().name().unwrap_or("").to_string();
+                let name = commit.author().unwrap().name.to_string();
                 let column_name = get_column_name(&alias_table, &"name".to_string());
                 attributes.insert(column_name, Value::Text(name));
                 continue;
             }
 
             if field_name == "email" {
-                let email = commit.author().email().unwrap_or("").to_string();
+                let email = commit.author().unwrap().email.to_string();
                 let column_name = get_column_name(&alias_table, &"email".to_string());
                 attributes.insert(column_name, Value::Text(email));
                 continue;
@@ -272,34 +287,46 @@ fn select_diffs(
                 || field_name == "deletions"
                 || field_name == "files_changed"
             {
-                let diff = if commit.parents().len() > 0 {
-                    repo.diff_tree_to_tree(
-                        Some(&commit.parent(0).unwrap().tree().unwrap()),
-                        Some(&commit.tree().unwrap()),
-                        None,
+                let current = commit.tree().unwrap();
+                let previous = commit_info
+                    .parent_ids()
+                    .next()
+                    .map(|id| id.object().unwrap().into_commit().tree().unwrap())
+                    .unwrap_or_else(|| repo.empty_tree());
+                let (mut insertions, mut deletions, mut files_changed) = (0, 0, 0);
+                previous
+                    .changes()
+                    .unwrap()
+                    .for_each_to_obtain_tree(
+                        &current,
+                        |change| -> Result<_, gix::object::blob::diff::init::Error> {
+                            files_changed += usize::from(change.event.entry_mode().is_no_tree());
+                            if let Some(diff) = change.event.diff().transpose()? {
+                                let counts = diff.line_counts();
+                                deletions += counts.removals;
+                                insertions += counts.insertions;
+                            }
+                            Ok(gix::object::tree::diff::Action::Continue)
+                        },
                     )
-                } else {
-                    repo.diff_tree_to_tree(None, Some(&commit.tree().unwrap()), None)
-                };
-
-                let diff_status = diff.unwrap().stats().unwrap();
+                    .unwrap();
 
                 if field_name == "insertions" {
-                    let insertions = Value::Number(diff_status.insertions() as i64);
+                    let insertions = Value::Number(insertions as i64);
                     let column_name = get_column_name(&alias_table, &"insertions".to_string());
                     attributes.insert(column_name, insertions);
                     continue;
                 }
 
                 if field_name == "deletions" {
-                    let deletations = Value::Number(diff_status.deletions() as i64);
+                    let deletations = Value::Number(deletions as i64);
                     let column_name = get_column_name(&alias_table, &"deletions".to_string());
                     attributes.insert(column_name, deletations);
                     continue;
                 }
 
                 if field_name == "files_changed" {
-                    let file_changed = Value::Number(diff_status.files_changed() as i64);
+                    let file_changed = Value::Number(files_changed as i64);
                     let column_name = get_column_name(&alias_table, &"files_changed".to_string());
                     attributes.insert(column_name, file_changed);
                     continue;
@@ -315,21 +342,24 @@ fn select_diffs(
 }
 
 fn select_branches(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     fields_names: &Vec<String>,
     fields_values: &Vec<Box<dyn Expression>>,
     alias_table: &HashMap<String, String>,
 ) -> Vec<GQLObject> {
     let mut branches: Vec<GQLObject> = Vec::new();
-    let local_branches = repo.branches(None).unwrap();
+    let platform = repo.references().unwrap();
+    let local_branches = platform.local_branches().unwrap();
     let repo_path = repo.path().to_str().unwrap().to_string();
 
     let names_len = fields_names.len() as i64;
     let values_len = fields_values.len() as i64;
     let padding = names_len - values_len;
 
+    let head_ref = repo.head_ref().unwrap().unwrap();
+
     for branch in local_branches {
-        let (branch, _) = branch.unwrap();
+        let branch = branch.unwrap();
 
         let mut attributes: HashMap<String, Value> = HashMap::new();
         for index in 0..names_len {
@@ -350,16 +380,14 @@ fn select_branches(
             }
 
             if field_name == "name" {
-                let branch_name = branch.name().unwrap().unwrap_or("").to_string();
+                let branch_name = branch.name().as_bstr().to_string();
                 let column_name = get_column_name(&alias_table, &"name".to_string());
                 attributes.insert(column_name, Value::Text(branch_name));
                 continue;
             }
 
             if field_name == "commit_count" {
-                let branch_ref = branch.get().peel_to_commit().unwrap();
-                let mut revwalk = repo.revwalk().unwrap();
-                let _ = revwalk.push(branch_ref.id());
+                let revwalk = branch.id().ancestors().all().unwrap();
                 let column_name = get_column_name(&alias_table, &"commit_count".to_string());
                 attributes.insert(column_name, Value::Number(revwalk.count() as i64));
                 continue;
@@ -367,13 +395,21 @@ fn select_branches(
 
             if field_name == "is_head" {
                 let column_name = get_column_name(&alias_table, &"is_head".to_string());
-                attributes.insert(column_name, Value::Boolean(branch.is_head()));
+                attributes.insert(column_name, Value::Boolean(branch.inner == head_ref.inner));
                 continue;
             }
 
             if field_name == "is_remote" {
                 let column_name = get_column_name(&alias_table, &"is_remote".to_string());
-                attributes.insert(column_name, Value::Boolean(branch.get().is_remote()));
+                attributes.insert(
+                    column_name,
+                    Value::Boolean(
+                        branch
+                            .name()
+                            .category()
+                            .map_or(false, |cat| cat == Category::RemoteBranch),
+                    ),
+                );
                 continue;
             }
 
@@ -392,22 +428,23 @@ fn select_branches(
 }
 
 fn select_tags(
-    repo: &git2::Repository,
+    repo: &gix::Repository,
     fields_names: &Vec<String>,
     fields_values: &Vec<Box<dyn Expression>>,
     alias_table: &HashMap<String, String>,
 ) -> Vec<GQLObject> {
     let mut tags: Vec<GQLObject> = Vec::new();
-    let tag_names = repo.tag_names(None).unwrap();
+    let platform = repo.references().unwrap();
+    let tag_names = platform.tags().unwrap();
     let repo_path = repo.path().to_str().unwrap().to_string();
 
     let names_len = fields_names.len() as i64;
     let values_len = fields_values.len() as i64;
     let padding = names_len - values_len;
 
-    for tag_name in tag_names.iter() {
+    for tag_name in tag_names {
         match tag_name {
-            Some(name) => {
+            Ok(tag_ref) => {
                 let mut attributes: HashMap<String, Value> = HashMap::new();
 
                 for index in 0..names_len {
@@ -429,7 +466,17 @@ fn select_tags(
 
                     if field_name == "name" {
                         let column_name = get_column_name(&alias_table, &"name".to_string());
-                        attributes.insert(column_name, Value::Text(name.to_string()));
+                        attributes.insert(
+                            column_name,
+                            Value::Text(
+                                tag_ref
+                                    .name()
+                                    .category_and_short_name()
+                                    .map_or_else(String::default, |(_, short_name)| {
+                                        short_name.to_string()
+                                    }),
+                            ),
+                        );
                         continue;
                     }
 
@@ -443,14 +490,14 @@ fn select_tags(
                 let gql_tag = GQLObject { attributes };
                 tags.push(gql_tag);
             }
-            None => {}
+            Err(_) => {}
         }
     }
     return tags;
 }
 
 fn select_values(
-    _repo: &git2::Repository,
+    _repo: &gix::Repository,
     fields_names: &Vec<String>,
     fields_values: &Vec<Box<dyn Expression>>,
     alias_table: &HashMap<String, String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,11 @@ fn main() {
 
     let arguments = arguments::parse_arguments();
     let mut reporter = reporter::DiagnosticReporter::new();
-    let mut git_repositories: Vec<git2::Repository> = vec![];
+    let mut git_repositories: Vec<gix::Repository> = vec![];
     for repsitory in arguments.repos {
-        let git_repository = git2::Repository::open(repsitory);
+        let git_repository = gix::open(repsitory);
         if git_repository.is_err() {
-            reporter.report_error(git_repository.err().unwrap().message());
+            reporter.report_error(&git_repository.err().unwrap().to_string());
             return;
         }
         git_repositories.push(git_repository.ok().unwrap());


### PR DESCRIPTION
This converts `git2` to `gix` for performance and compatibility improvements.

Please note that due to a lack of tests, there might be differences in
the details, so careful manual verification is advised.

Further, I definitely recommend to use `anyhow` and `?` instead of unwrapping everywhere.

Lastly, a simple start for automatic protection from regression would be something like 
a command mode `gitql -c "select *..."` in a well-known repository so one can compare
its output with a known good output.

For that to work though, one would ahve to avoid using hashsets or hashmaps for column names
so these stop changes their order each time.
