### PR TITLE
add CONCAT function #13

### DIFF
--- a/crates/gitql-ast/src/function.rs
+++ b/crates/gitql-ast/src/function.rs
@@ -34,6 +34,7 @@ lazy_static! {
         map.insert("stuff", text_stuff);
         map.insert("right", text_right);
         map.insert("translate", text_translate);
+        map.insert("concat", text_concat);
 
         // Date functions
         map.insert("current_date", date_current_date);
@@ -170,6 +171,13 @@ lazy_static! {
             "translate",
             Prototype {
                 parameters: vec![DataType::Text, DataType::Text, DataType::Text],
+                result: DataType::Text
+             },
+        );
+        map.insert(
+            "concat",
+            Prototype {
+                parameters: vec![DataType::Text, DataType::Text],
                 result: DataType::Text
              },
         );
@@ -370,6 +378,11 @@ fn text_translate(inputs: Vec<Value>) -> Value {
     }
 
     return Value::Text(text);
+}
+
+fn text_concat(inputs: Vec<Value>) -> Value {
+    let text: Vec<String> = inputs.iter().map(|v| v.as_text()).collect();
+    return Value::Text(text.concat());
 }
 
 // Date functions

--- a/docs/function/functions.md
+++ b/docs/function/functions.md
@@ -23,7 +23,7 @@ note that all functions names are case-insensitive.
 | STUFF      | Text, Number, Number, Text | Text   | Deletes a part of a string and then inserts another part into the string, starting at a specified position.                                                          |
 | RIGHT      | Text, Number               | Text   | Extracts a number of characters from a string (starting from right).                                                                                                 |
 | TRANSLATE  | Text, Text, Text,          | Text   | Returns the string from the first argument after the characters specified in the second argument are translated into the characters specified in the third argument. |
-| CONCAT     | Text, Text                 | Text   | Add two strings together.                                                   |
+| CONCAT     | Text, Text                 | Text   | Adds two or more strings together.                                          |
 ### String functions samples
 
 ```sql

--- a/docs/function/functions.md
+++ b/docs/function/functions.md
@@ -23,6 +23,7 @@ note that all functions names are case-insensitive.
 | STUFF      | Text, Number, Number, Text | Text   | Deletes a part of a string and then inserts another part into the string, starting at a specified position.                                                          |
 | RIGHT      | Text, Number               | Text   | Extracts a number of characters from a string (starting from right).                                                                                                 |
 | TRANSLATE  | Text, Text, Text,          | Text   | Returns the string from the first argument after the characters specified in the second argument are translated into the characters specified in the third argument. |
+| CONCAT     | Text, Text                 | Text   | Add two strings together.                                                   |
 ### String functions samples
 
 ```sql
@@ -41,6 +42,7 @@ SELECT name, SUBSTRING(name, 1, 5) AS extract FROM commits
 SELECT STUFF("GQL tutorial!", 13, 1, " is fun!")
 SELECT RIGHT("AmrDeveloper", 3) AS extract
 SELECT TRANSLATE("Amr[Dev]{eloper}", "[]{}", "()()")
+SELECT CONCAT("amrdeveloper", ".github.io")
 ```
 
 ### Date functions


### PR DESCRIPTION
For Issue #13. This is different from SQL because it only supports 2 arguments. SQL can concatenate any number of strings together. But I didn't see way around the validation on the number of arguments, so hard-coded to two.