### PR TITLE
chore: fix typos in sample queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ SELECT LEN("Git Query Language")
 SELECT "One" IN ("One", "Two", "Three")
 SELECT "Git Query Language" LIKE "%Query%"
 
-SELECT DISTINCT title AS tt message FROM commits
+SELECT DISTINCT title AS tt FROM commits
 SELECT name, COUNT(name) AS commit_num FROM commits GROUP BY name ORDER BY commit_num DESC LIMIT 10
 SELECT commit_count FROM branches WHERE commit_count BETWEEN 0 .. 10
 

--- a/docs/statement/select.md
+++ b/docs/statement/select.md
@@ -21,12 +21,12 @@ SELECT count(name) FROM commits
 You can alias the column name only in this query by using `as` keyword for example
 
 ```sql
-SELECT title as tt message FROM commits
+SELECT title as tt FROM commits
 SELECT name, commit_count, max(commit_count) AS max_count message FROM branches
 ```
 
 You can select unique rows only using the `distinct` keyword for example,
 
 ```sql
-SELECT DISTINCT title AS tt message FROM commits
+SELECT DISTINCT title AS tt FROM commits
 ```


### PR DESCRIPTION
The sample query, as written, didn't execute for me.

```
gql > SELECT DISTINCT title AS tt message FROM commits
----------------------------------^
Compiletime ERROR: [28 - 35] -> Unexpected statement
```