### PR TITLE
fix: typo

### DIFF
--- a/crates/gitql-cli/src/arguments.rs
+++ b/crates/gitql-cli/src/arguments.rs
@@ -51,7 +51,7 @@ pub fn parse_arguments(args: &Vec<String>) -> Command {
         let arg = &args[arg_index];
 
         if !arg.starts_with('-') {
-            return Command::Error(format!("Unkown argument {}", arg));
+            return Command::Error(format!("Unknown argument {}", arg));
         }
 
         match arg.as_ref() {
@@ -111,7 +111,7 @@ pub fn parse_arguments(args: &Vec<String>) -> Command {
                 arguments.page_size = page_size;
                 arg_index += 1;
             }
-            _ => return Command::Error(format!("Unkown command {}", arg)),
+            _ => return Command::Error(format!("Unknown command {}", arg)),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,8 @@ fn main() {
         Command::Version => {
             println!("GitQL version {}", env!("CARGO_PKG_VERSION"));
         }
-        Command::Error(error_mssage) => {
-            println!("{}", error_mssage);
+        Command::Error(error_message) => {
+            println!("{}", error_message);
         }
     }
 }


### PR DESCRIPTION
I found some typos, if you are using VS Code, you can try the `streetsidesoftware.code-spell-checker` extensin.