### PR TITLE
add `quotename` string function #13

### DIFF
--- a/docs/function/functions.md
+++ b/docs/function/functions.md
@@ -30,6 +30,7 @@ note that all functions names are case-insensitive.
 | CONCAT_WS  | Text, Any, Any, ...Any       | Text    | Add several string representations of values together together with separate.                                                                                        |
 | UNICODE    | Text                         | Integer | Return an integer value (the Unicode value), for the first character of the input expression.                                                                        |
 | STRCMP     | Text , Text                  | Integer | Return 0 If string1 = string2, -1 if string1 < string2, this function returns -1, and 1 if string1 > string2                                                         |
+| QUOTENAME  | Text , Text                  | Text    | Returns the string (first argument) with specified delimiters (second argument), defaulting to []                                                                    |
 
 ### String functions samples
 
@@ -54,6 +55,9 @@ SELECT SOUNDEX("AmrDeveloper") as code
 SELECT CONCAT("amrdeveloper", ".github.io")
 SELECT CONCAT_WS("_", "Git", "Query", "Language"); 
 SELECT UNICODE("AmrDeveloper")
+SELECT QUOTENAME("AmrDeveloper")
+SELECT QUOTENAME("AmrDeveloper", ".")
+SELECT QUOTENAME("AmrDeveloper", "{}")
 ```
 
 ### Date functions


### PR DESCRIPTION
## Implement `QUOTENAME`

Returns the first string argument with delimiters added. The second argument is used to specify the delimiters. It's by default set to `[]`. The delimiters must at most be of length 2 otherwise a `null` is returned. When the delimiter string contains one argument it will be used as the starting and ending delimiter, if the delimiter string contains two character, the first one will be used as the starting delimiter and the second one will be used as the ending delimiter.

![2024-02-26T22:46:06,642347615+03:00](https://github.com/AmrDeveloper/GQL/assets/53809656/9ec2f8d3-8298-4db2-a7e8-c65a6cdd285d)
